### PR TITLE
Revert "new version 0.11.0"

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "idds-common" %}
-{% set version = "0.11.0" %}
+{% set version = "0.10.9" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 3f11128205eead70e41c744357816416b088503b6af3f75ed32bc3009ae85d0a
+  sha256: 5e3ef88059ad07f54163934fcac46e2fddc4c30c786eb669bb2849c9ce463d90
 
 build:
   number: 0


### PR DESCRIPTION
Reverts conda-forge/idds-common-feedstock#35